### PR TITLE
Empty delimiter and mixed op fix

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,14 +1,15 @@
 use crate::token::Token;
 
 #[derive(Clone, Copy, Debug)]
-pub struct Expression<'s, O> {
-    pub kind: ExpressionKind<O>,
+pub struct Expression<'s, B, U> {
+    pub kind: ExpressionKind<B, U>,
     pub token: Token<'s>,
 }
 
 #[derive(Clone, Copy, Debug)]
-pub enum ExpressionKind<O> {
-    Operator(O),
+pub enum ExpressionKind<B, U> {
+    BinaryOperator(B),
+    UnaryOperator(U),
     Integer(i64),
     Float(f64),
     String,

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -14,4 +14,5 @@ pub enum ExpressionKind<B, U> {
     Float(f64),
     String,
     Variable,
+    Null,
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -553,7 +553,10 @@ mod tests {
     #[test_case("sin(max(5/2, 3)) / 3 * pi", "sin max 5 2 / 3 , ( ( 3 / pi *" ; "with functions" )]
     #[test_case("2^3!", "2 3 ! ^" ; "postfix operators" )]
     #[test_case("-2^3 + (-2)^3", "2 3 ^ - 2 - 3 ^ +" ; "prefix operators" )]
-    #[test_case("[1, (2, 3), 4]", "1 2 3 , , 4 , [" ; "delimiter operators" )]
+    #[test_case("[1, 2, 3, 4]", "1 2 , 3 , 4 , [" ; "delimiter operators" )]
+    #[test_case("[1, (2, 3), 4]", "1 2 3 , , 4 , [" ; "nested delimiter operators" )]
+    #[test_case("[ ]", "[" ; "empty list" )]
+    #[test_case("f()", "f (" ; "empty function call" )]
     fn parse_expression(input: &str, output: &str) -> anyhow::Result<()> {
         let actual = Parser::new(input, SimpleExprContext)
             .parse()?

--- a/src/token.rs
+++ b/src/token.rs
@@ -29,7 +29,7 @@ impl<'s> Tokenizer<'s> {
         self.remainder.is_empty()
     }
 
-    pub fn next_token(&mut self) -> Option<Token<'s>> {
+    pub fn next_token(&mut self) -> Option<(Token<'s>, TokenKind)> {
         // skip whitespace
         if self.next_if(char::is_whitespace).is_some() {
             self.advance_while(char::is_whitespace);
@@ -47,11 +47,13 @@ impl<'s> Tokenizer<'s> {
             }
         };
         let end = self.next_index();
-        Some(Token {
-            span: Span { start, end },
-            source: self.source,
+        Some((
+            Token {
+                span: Span { start, end },
+                source: self.source,
+            },
             kind,
-        })
+        ))
     }
 
     fn lex_number(&mut self, has_dot: bool) -> TokenKind {
@@ -155,10 +157,13 @@ impl<'s> Tokenizer<'s> {
 pub struct Token<'s> {
     span: Span,
     source: &'s str,
-    kind: TokenKind,
 }
 
 impl<'s> Token<'s> {
+    pub fn new(span: Span, source: &'s str) -> Self {
+        Token { span, source }
+    }
+
     pub fn span(&self) -> Span {
         self.span
     }
@@ -169,10 +174,6 @@ impl<'s> Token<'s> {
 
     pub fn as_str(&self) -> &'s str {
         &self.source[self.span.into_range()]
-    }
-
-    pub fn kind(&self) -> TokenKind {
-        self.kind
     }
 }
 
@@ -312,7 +313,7 @@ mod tests {
     #[test_case("(((", TokenKind::Tag, "(" ; "singleton")]
     fn lex_one(source: &str, kind: TokenKind, as_str: &str) {
         let actual = Tokenizer::new(source).next_token().unwrap();
-        assert_eq!(actual.kind, kind);
-        assert_eq!(actual.as_str(), as_str);
+        assert_eq!(actual.1, kind);
+        assert_eq!(actual.0.as_str(), as_str);
     }
 }


### PR DESCRIPTION
Allows parsing closing delimiters in prefix position, to allow for empty delimiters and operators like `,` whose right-hand-sides are optional. This is implemented by inserting a `Null` expression onto the queue when a closing delimiter is encountered in these positions.