### PR TITLE
[#4] Improve ergonomics of `ParseContext`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -552,6 +552,7 @@ mod tests {
     enum SimpleDelimiter {
         Paren,
         SquareBracket,
+        Pipe,
     }
 
     impl Delimiter for SimpleDelimiter {
@@ -605,6 +606,16 @@ mod tests {
                     },
                     postfix: Postfix::RightDelimiter {
                         delimiter: SimpleDelimiter::SquareBracket,
+                    },
+                },
+                "|" => Element {
+                    prefix: Prefix::LeftDelimiter {
+                        delimiter: SimpleDelimiter::Pipe,
+                        operator: Some(s),
+                        rhs_required: true,
+                    },
+                    postfix: Postfix::RightDelimiter {
+                        delimiter: SimpleDelimiter::Pipe,
                     },
                 },
                 "," => Element {
@@ -675,6 +686,7 @@ mod tests {
     #[test_case("[ ]", "] [" ; "empty list" )]
     #[test_case("f()", "f ) (" ; "empty function call" )]
     #[test_case("[1, 2, 3, 4, ]", "1 2 , 3 , 4 , ] , [" ; "trailing comma" )]
+    #[test_case("a * |b|", "a b | *" ; "absolute value" )]
     fn parse_expression(input: &str, output: &str) -> anyhow::Result<()> {
         let actual = Parser::new(SimpleTokenizer::new(input), SimpleExprContext)
             .parse()?


### PR DESCRIPTION
I'm a bit disappointed in how little I was able to improve this, but I think there's just enough edge cases that a simpler design isn't possible. At least merging the `get_prefix` and `get_postfix` functions makes it easier to keep the two contexts in sync with one another.

Fixes #4 