### PR TITLE
[#5] Evaluator

### DIFF
--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -58,3 +58,39 @@ where
 
     Ok(stack.pop().expect(STACK_EMPTY))
 }
+
+/// An `EvaluationContext` whose `Value` type is the same as its `Term` type, and whose operators
+/// are pure functions on that type that return `Result<Term, E>`
+pub struct PureEvaluator;
+
+impl<'s, B, U, T, E> EvaluationContext<'s, B, U, T> for PureEvaluator
+where
+    B: FnOnce(T, T) -> Result<T, E>,
+    U: FnOnce(T) -> Result<T, E>,
+{
+    type Value = T;
+    type Error = E;
+
+    fn evaluate_binary_operator(
+        &self,
+        _token: Token<'s>,
+        operator: B,
+        lhs: Self::Value,
+        rhs: Self::Value,
+    ) -> Result<Self::Value, Self::Error> {
+        operator(lhs, rhs)
+    }
+
+    fn evaluate_unary_operator(
+        &self,
+        _token: Token<'s>,
+        operator: U,
+        argument: Self::Value,
+    ) -> Result<Self::Value, Self::Error> {
+        operator(argument)
+    }
+
+    fn evaluate_term(&self, _token: Token<'s>, term: T) -> Result<Self::Value, Self::Error> {
+        Ok(term)
+    }
+}

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -1,0 +1,60 @@
+use crate::{
+    expression::{Expression, ExpressionKind},
+    token::Token,
+};
+
+pub trait EvaluationContext<'s, B, U, T> {
+    type Value;
+    type Error;
+
+    fn evaluate_binary_operator(
+        &self,
+        token: Token<'s>,
+        operator: B,
+        lhs: Self::Value,
+        rhs: Self::Value,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn evaluate_unary_operator(
+        &self,
+        token: Token<'s>,
+        operator: U,
+        argument: Self::Value,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn evaluate_term(&self, token: Token<'s>, term: T) -> Result<Self::Value, Self::Error>;
+}
+
+/// Evaluate the input expression queue using the provided `EvaluationContext`.
+///
+/// # Panics
+///
+/// This function will panic if it encounters an operator and the stack does not contain enough
+/// values for the operator's arguments. It will also panic if the input is empty.
+pub fn evaluate<'s, C, I, B, U, T>(context: &C, input: I) -> Result<C::Value, C::Error>
+where
+    C: EvaluationContext<'s, B, U, T>,
+    I: IntoIterator<Item = Expression<'s, B, U, T>>,
+{
+    const STACK_EMPTY: &str = "tried to pop from empty stack";
+
+    let mut stack = Vec::new();
+    for expr in input {
+        match expr.kind {
+            ExpressionKind::BinaryOperator(op) => {
+                let rhs = stack.pop().expect(STACK_EMPTY);
+                let lhs = stack.pop().expect(STACK_EMPTY);
+                stack.push(context.evaluate_binary_operator(expr.token, op, lhs, rhs)?);
+            }
+            ExpressionKind::UnaryOperator(op) => {
+                let argument = stack.pop().expect(STACK_EMPTY);
+                stack.push(context.evaluate_unary_operator(expr.token, op, argument)?);
+            }
+            ExpressionKind::Term(term) => {
+                stack.push(context.evaluate_term(expr.token, term)?);
+            }
+        }
+    }
+
+    Ok(stack.pop().expect(STACK_EMPTY))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use std::{fmt, ops::Range};
 
 pub mod error;
+pub mod evaluate;
 pub mod expression;
 pub mod operator;
 pub mod parser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,13 @@ pub struct Span {
 }
 
 impl Span {
+    pub const fn new(range: Range<usize>) -> Self {
+        Self {
+            start: range.start,
+            end: range.end,
+        }
+    }
+
     /// Creates a new span encompassing both input spans.
     pub fn join(self, other: Self) -> Self {
         Span {
@@ -35,10 +42,7 @@ impl From<Span> for Range<usize> {
 
 impl From<Range<usize>> for Span {
     fn from(range: Range<usize>) -> Self {
-        Span {
-            start: range.start,
-            end: range.end,
-        }
+        Self::new(range)
     }
 }
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -244,15 +244,15 @@ pub struct Token<'s> {
 }
 
 impl<'s> Token<'s> {
-    pub fn new(span: Span, source: &'s str) -> Self {
+    pub const fn new(span: Span, source: &'s str) -> Self {
         Token { span, source }
     }
 
-    pub fn span(&self) -> Span {
+    pub const fn span(&self) -> Span {
         self.span
     }
 
-    pub fn source(&self) -> &'s str {
+    pub const fn source(&self) -> &'s str {
         self.source
     }
 


### PR DESCRIPTION
Closes #5 

Adds a new `evaluator` module, including a `PureEvaluator` struct, for very simple evaluators with no state.