### PR TITLE
Improve parser error handling

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -241,9 +241,7 @@ where
                 };
                 if let Some(left) = el.delimiter {
                     self.state = State::PostTerm;
-                    if let Err(err) = Self::check_delimiter_match(left, el.token, right, token) {
-                        self.errors.push(err);
-                    }
+                    self.check_delimiter_match(left, el.token, right, token);
                     return;
                 }
             }
@@ -257,9 +255,7 @@ where
                 });
             }
             if let Some(left) = el.delimiter {
-                if let Err(err) = Self::check_delimiter_match(left, el.token, right, token) {
-                    self.errors.push(err);
-                }
+                self.check_delimiter_match(left, el.token, right, token);
                 return;
             }
         }
@@ -270,20 +266,19 @@ where
     }
 
     fn check_delimiter_match(
+        &mut self,
         left: C::Delimiter,
         left_token: Token<'s>,
         right: C::Delimiter,
         right_token: Token<'s>,
-    ) -> Result<(), ParseError<C::Error>> {
-        if left.matches(&right) {
-            Ok(())
-        } else {
-            Err(ParseError {
+    ) {
+        if !left.matches(&right) {
+            self.errors.push(ParseError {
                 kind: ParseErrorKind::MismatchedDelimiter {
                     opening: left_token.span(),
                 },
                 span: right_token.span(),
-            })
+            });
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -746,6 +746,10 @@ mod tests {
     #[test_case("[ 1 )", &[
         (ParseErrorKind::MismatchedDelimiter { opening: (0..1).into() }, 4..5),
     ] ; "mismatched delimiters" )]
+    #[test_case("( [ 1 )", &[
+        (ParseErrorKind::MismatchedDelimiter { opening: (2..3).into() }, 6..7),
+        (ParseErrorKind::UnmatchedLeftDelimiter, 0..1),
+    ] ; "mismatched delimiters 2" )]
     #[test_case("[ 1 + )", &[
         (ParseErrorKind::UnexpectedToken { expected: EXPECT_TERM }, 6..7),
         (ParseErrorKind::MismatchedDelimiter { opening: (0..1).into() }, 6..7),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -155,7 +155,6 @@ where
                             kind,
                             token: el.token,
                         });
-                        self.parse_operator(token, element);
                     } else {
                         self.errors.push(ParseError {
                             kind: ParseErrorKind::UnexpectedToken {
@@ -165,6 +164,7 @@ where
                         });
                     };
                 }
+                self.parse_operator(token, element);
             }
         }
     }
@@ -752,7 +752,6 @@ mod tests {
     ] ; "mismatched delimiters with missing rhs" )]
     #[test_case("1 + * 2", &[
         (ParseErrorKind::UnexpectedToken { expected: EXPECT_TERM }, 4..5),
-        (ParseErrorKind::UnexpectedToken { expected: EXPECT_OPERATOR }, 6..7),
     ] ; "extra operator" )]
     fn parse_expression_fail(
         input: &str,


### PR DESCRIPTION
Moves the `errors` vec into the `Parser` struct, so that it is possible to return multiple errors from individual parser functions.