### PR TITLE
Support fallible tokenizers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["emily Crandall Fleischman <emilycf@mit.edu>"]
 license = "MIT"
 
 [dependencies]
+bstr = "1.9.1"
 itertools = "0.10.5"
 thiserror = "1.0.38"
 unicode-xid = "0.2.4"

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,11 +3,11 @@ use std::fmt;
 use crate::Span;
 
 #[derive(Clone, Debug, thiserror::Error)]
-pub struct ParseErrors<E> {
-    pub errors: Vec<ParseError<E>>,
+pub struct ParseErrors<P, T> {
+    pub errors: Vec<ParseError<P, T>>,
 }
 
-impl<E: fmt::Display> fmt::Display for ParseErrors<E> {
+impl<P: fmt::Display, T: fmt::Display> fmt::Display for ParseErrors<P, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.errors.len() == 1 {
             f.write_str("Encountered 1 error:\n")?;
@@ -21,21 +21,21 @@ impl<E: fmt::Display> fmt::Display for ParseErrors<E> {
     }
 }
 
-impl<E> From<Vec<ParseError<E>>> for ParseErrors<E> {
-    fn from(errors: Vec<ParseError<E>>) -> Self {
+impl<P, T> From<Vec<ParseError<P, T>>> for ParseErrors<P, T> {
+    fn from(errors: Vec<ParseError<P, T>>) -> Self {
         ParseErrors { errors }
     }
 }
 
 #[derive(Clone, Copy, Debug, thiserror::Error)]
 #[error("Parse error at {span}: {kind}")]
-pub struct ParseError<E> {
+pub struct ParseError<P, T> {
     pub span: Span,
-    pub kind: ParseErrorKind<E>,
+    pub kind: ParseErrorKind<P, T>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
-pub enum ParseErrorKind<E> {
+pub enum ParseErrorKind<P, T> {
     #[error("Unexpected end of input (expected {expected})")]
     EndOfInput { expected: &'static str },
     #[error("Unexpected token (expected {expected})")]
@@ -47,7 +47,9 @@ pub enum ParseErrorKind<E> {
     #[error("Unmatched opening delimiter")]
     UnmatchedLeftDelimiter,
     #[error(transparent)]
-    Other(E),
+    Parser(P),
+    #[error(transparent)]
+    Tokenizer(T),
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,6 +52,23 @@ pub enum ParseErrorKind<P, T> {
     Tokenizer(T),
 }
 
+impl<P, T> ParseErrorKind<P, T> {
+    #[cfg(test)]
+    pub(crate) fn map_tokenizer_error<U>(self, f: impl FnOnce(T) -> U) -> ParseErrorKind<P, U> {
+        match self {
+            Self::EndOfInput { expected } => ParseErrorKind::EndOfInput { expected },
+            Self::UnexpectedToken { expected } => ParseErrorKind::UnexpectedToken { expected },
+            Self::MismatchedDelimiter { opening } => {
+                ParseErrorKind::MismatchedDelimiter { opening }
+            }
+            Self::UnmatchedRightDelimiter => ParseErrorKind::UnmatchedRightDelimiter,
+            Self::UnmatchedLeftDelimiter => ParseErrorKind::UnmatchedLeftDelimiter,
+            Self::Parser(e) => ParseErrorKind::Parser(e),
+            Self::Tokenizer(e) => ParseErrorKind::Tokenizer(f(e)),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
 pub enum ParseIntError {
     #[error("Empty string")]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -633,7 +633,7 @@ mod tests {
         error::ParseErrorKind,
         expression::{Expression, ExpressionKind},
         operator::Fixity,
-        token::{SimpleCharSetTokenKind, SimpleTokenizer, StrSource, Tokenizer},
+        token::{SimpleCharSetTokenKind, SimpleTokenizer, SimpleTokenizerError, StrSource},
     };
 
     struct SimpleExprContext;
@@ -872,7 +872,7 @@ mod tests {
     fn parse_expression_fail(
         input: &str,
         expected: &[(
-            ParseErrorKind<Infallible, <SimpleTokenizer as Tokenizer>::Error>,
+            ParseErrorKind<Infallible, SimpleTokenizerError>,
             Range<usize>,
         )],
     ) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -63,9 +63,7 @@ impl<T: Tokenizer, P: Parser<T::Token>> ParseHelper<T, P> {
     }
 
     /// Parses until the end of input
-    fn parse_all(
-        mut self,
-    ) -> Result<ExpressionQueue<P, T>, ParseErrors<P::Error, T::Error>> {
+    fn parse_all(mut self) -> Result<ExpressionQueue<P, T>, ParseErrors<P::Error, T::Error>> {
         let mut end_of_input = 0;
         while let Some(token) = self.tokenizer.next_token() {
             self.handle_token_result(token, &mut end_of_input);
@@ -77,9 +75,7 @@ impl<T: Tokenizer, P: Parser<T::Token>> ParseHelper<T, P> {
     ///
     /// This means zero or more prefix operators followed by either a term token or a delimited
     /// group.
-    fn parse_one_term(
-        mut self,
-    ) -> Result<ExpressionQueue<P, T>, ParseErrors<P::Error, T::Error>> {
+    fn parse_one_term(mut self) -> Result<ExpressionQueue<P, T>, ParseErrors<P::Error, T::Error>> {
         let mut end_of_input = 0;
         let mut delimiter_stack_index = None;
         while let Some(token) = self.tokenizer.next_token() {
@@ -625,7 +621,7 @@ fn parse_float(s: &str) -> Result<f64, ParseFloatError> {
 
 #[cfg(test)]
 mod tests {
-    use std::{ops::Range, convert::Infallible};
+    use std::{convert::Infallible, ops::Range};
 
     use test_case::test_case;
 
@@ -815,10 +811,13 @@ mod tests {
     #[test_case("a * |b|", "a b | *" ; "absolute value" )]
     #[test_case("a, * b", "a (,) b *" ; "trailing comma with binary operator" )]
     fn parse_expression(input: &str, output: &str) -> anyhow::Result<()> {
-        let actual = parse(SimpleTokenizer::new(StrSource::new(input)), SimpleExprContext)?
-            .into_iter()
-            .map(expr_to_str)
-            .collect::<Vec<_>>();
+        let actual = parse(
+            SimpleTokenizer::new(StrSource::new(input)),
+            SimpleExprContext,
+        )?
+        .into_iter()
+        .map(expr_to_str)
+        .collect::<Vec<_>>();
         let expected = output.split_whitespace().collect::<Vec<_>>();
         assert_eq!(actual, expected);
         Ok(())
@@ -839,7 +838,9 @@ mod tests {
             .collect::<Vec<_>>();
         let expected = output.split_whitespace().collect::<Vec<_>>();
         assert_eq!(actual, expected);
-        let actual_rest = tokens.map(|res| res.map(|tok| tok.kind)).collect::<Result<Vec<_>, _>>()?;
+        let actual_rest = tokens
+            .map(|res| res.map(|tok| tok.kind))
+            .collect::<Result<Vec<_>, _>>()?;
         let expected_rest = SimpleTokenizer::new(StrSource::new(rest))
             .map(|res| res.map(|tok| tok.kind))
             .collect::<Result<Vec<_>, _>>()?;
@@ -870,14 +871,20 @@ mod tests {
     ] ; "extra operator" )]
     fn parse_expression_fail(
         input: &str,
-        expected: &[(ParseErrorKind<Infallible, <SimpleTokenizer as Tokenizer>::Error>, Range<usize>)],
+        expected: &[(
+            ParseErrorKind<Infallible, <SimpleTokenizer as Tokenizer>::Error>,
+            Range<usize>,
+        )],
     ) {
-        let actual = parse(SimpleTokenizer::new(StrSource::new(input)), SimpleExprContext)
-            .unwrap_err()
-            .errors
-            .into_iter()
-            .map(|err| (err.kind, err.span.into_range()))
-            .collect::<Vec<_>>();
+        let actual = parse(
+            SimpleTokenizer::new(StrSource::new(input)),
+            SimpleExprContext,
+        )
+        .unwrap_err()
+        .errors
+        .into_iter()
+        .map(|err| (err.kind, err.span.into_range()))
+        .collect::<Vec<_>>();
         assert_eq!(actual, expected);
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -633,7 +633,7 @@ mod tests {
         error::ParseErrorKind,
         expression::{Expression, ExpressionKind},
         operator::Fixity,
-        token::{SimpleCharSetTokenKind, SimpleTokenizer, SimpleTokenizerError, StrSource},
+        token::{SimpleCharSetTokenKind, SimpleTokenizer, StrSource},
     };
 
     struct SimpleExprContext;
@@ -871,10 +871,7 @@ mod tests {
     ] ; "extra operator" )]
     fn parse_expression_fail(
         input: &str,
-        expected: &[(
-            ParseErrorKind<Infallible, SimpleTokenizerError>,
-            Range<usize>,
-        )],
+        expected: &[(ParseErrorKind<Infallible, Infallible>, Range<usize>)],
     ) {
         let actual = parse(
             SimpleTokenizer::new(StrSource::new(input)),
@@ -883,7 +880,12 @@ mod tests {
         .unwrap_err()
         .errors
         .into_iter()
-        .map(|err| (err.kind, err.span.into_range()))
+        .map(|err| {
+            (
+                err.kind.map_tokenizer_error(|_| unreachable!()),
+                err.span.into_range(),
+            )
+        })
         .collect::<Vec<_>>();
         assert_eq!(actual, expected);
     }

--- a/src/token.rs
+++ b/src/token.rs
@@ -216,7 +216,7 @@ impl<S: Source, C: CharSet<S::Char>> Tokenizer for CharSetTokenizer<S, C> {
     type Error = Either<S::Error, C::Error>;
 
     fn next_token(&mut self) -> Option<Result<Token<Self::Token>, Self::Error>> {
-        loop {
+        while !self.source.is_empty() {
             let start = self.source.next_index();
             match self.advance_while() {
                 Ok(Some(token)) => {
@@ -230,6 +230,7 @@ impl<S: Source, C: CharSet<S::Char>> Tokenizer for CharSetTokenizer<S, C> {
                 Err(err) => return Some(Err(err)),
             }
         }
+        None
     }
 }
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -474,13 +474,19 @@ mod tests {
     #[test_case(r#""abc\"\\\"\\""#, SimpleCharSetTokenKind::String, r#""abc\"\\\"\\""# ; "string")]
     #[test_case("(((", SimpleCharSetTokenKind::Tag, "(" ; "singleton")]
     fn lex_one(source: &str, kind: SimpleCharSetTokenKind, as_str: &str) {
-        let actual = SimpleTokenizer::new(StrSource::new(source)).next().unwrap().unwrap();
+        let actual = SimpleTokenizer::new(StrSource::new(source))
+            .next()
+            .unwrap()
+            .unwrap();
         assert_eq!(actual.kind, (as_str, kind));
     }
 
     #[test]
     fn unterminated_string() {
         let source = r#""abc\"\\\"abc"#;
-        SimpleTokenizer::new(StrSource::new(source)).next().unwrap().unwrap_err();
+        SimpleTokenizer::new(StrSource::new(source))
+            .next()
+            .unwrap()
+            .unwrap_err();
     }
 }


### PR DESCRIPTION
Also make `CharSetTokenizer` even more generic, including adding a `BufRead` based source.

Closes #18 