### PR TITLE
Other expression formats

### DIFF
--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -130,7 +130,7 @@ where
     evaluator.finish()
 }
 
-/// An `Evaluator` whose `Value` type is the same as its `Term` type, and whose operators
+/// An [`Evaluator`] whose `Value` type is the same as its `Term` type, and whose operators
 /// are pure functions on that type that return `Result<Term, E>`
 pub struct PureEvaluator;
 
@@ -164,6 +164,71 @@ where
     fn evaluate_term(&mut self, _span: Span<Idx>, term: T) -> Result<Self::Value, Self::Error> {
         Ok(term)
     }
+}
+
+/// An [`Evaluator`] which simply collects its expressions into an abstract syntax tree.
+pub struct TreeEvaluator;
+
+impl<Idx, B, U, T> Evaluator<Idx, B, U, T> for TreeEvaluator {
+    type Value = ExpressionTree<Idx, B, U, T>;
+    type Error = std::convert::Infallible;
+
+    fn evaluate_binary_operator(
+        &mut self,
+        span: Span<Idx>,
+        operator: B,
+        left: Self::Value,
+        right: Self::Value,
+    ) -> Result<Self::Value, Self::Error> {
+        Ok(ExpressionTree {
+            span,
+            node: Box::new(ExpressionNode::Binary {
+                operator,
+                left,
+                right,
+            }),
+        })
+    }
+
+    fn evaluate_unary_operator(
+        &mut self,
+        span: Span<Idx>,
+        operator: U,
+        argument: Self::Value,
+    ) -> Result<Self::Value, Self::Error> {
+        Ok(ExpressionTree {
+            span,
+            node: Box::new(ExpressionNode::Unary { operator, argument }),
+        })
+    }
+
+    fn evaluate_term(&mut self, span: Span<Idx>, value: T) -> Result<Self::Value, Self::Error> {
+        Ok(ExpressionTree {
+            span,
+            node: Box::new(ExpressionNode::Term { value }),
+        })
+    }
+}
+
+/// An abstract syntax tree representing an expression
+pub struct ExpressionTree<Idx, B, U, T> {
+    pub span: Span<Idx>,
+    pub node: Box<ExpressionNode<Idx, B, U, T>>,
+}
+
+pub enum ExpressionNode<Idx, B, U, T> {
+    Binary {
+        operator: B,
+        left: ExpressionTree<Idx, B, U, T>,
+        right: ExpressionTree<Idx, B, U, T>,
+    },
+    Unary {
+        operator: U,
+        argument: ExpressionTree<Idx, B, U, T>,
+    },
+    Term {
+        value: T,
+    },
 }
 
 #[cfg(test)]

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -23,13 +23,6 @@ pub trait Evaluator<Idx, B, U, T> {
     ) -> Result<Self::Value, Self::Error>;
 
     fn evaluate_term(&mut self, span: Span<Idx>, term: T) -> Result<Self::Value, Self::Error>;
-
-    fn evaluate<I>(&mut self, input: I) -> Result<Self::Value, Self::Error>
-    where
-        I: IntoIterator<Item = Expression<Idx, B, U, T>>,
-    {
-        evaluate(self, input)
-    }
 }
 
 pub struct ImmediateEvaluator<'e, E: ?Sized, V, Error> {
@@ -235,7 +228,7 @@ pub enum ExpressionNode<Idx, B, U, T> {
 mod tests {
     use test_case::test_case;
 
-    use super::{Evaluator, PureEvaluator};
+    use super::{evaluate, PureEvaluator};
     use crate::{
         expression::{Expression, ExpressionKind},
         Span,
@@ -295,10 +288,13 @@ mod tests {
         result: Result<Term, Error>,
     ) {
         const EMPTY_SPAN: Span<usize> = Span { start: 0, end: 0 };
-        let actual = PureEvaluator.evaluate(expression.into_iter().map(|kind| Expression {
-            kind,
-            span: EMPTY_SPAN,
-        }));
+        let actual = evaluate(
+            &mut PureEvaluator,
+            expression.into_iter().map(|kind| Expression {
+                kind,
+                span: EMPTY_SPAN,
+            }),
+        );
 
         assert_eq!(actual, result);
     }

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -25,18 +25,49 @@ pub trait Evaluator<Idx, B, U, T> {
     fn evaluate_term(&mut self, span: Span<Idx>, term: T) -> Result<Self::Value, Self::Error>;
 }
 
+impl<E, Idx, B, U, T> Evaluator<Idx, B, U, T> for &'_ mut E
+where
+    E: Evaluator<Idx, B, U, T> + ?Sized,
+{
+    type Value = E::Value;
+    type Error = E::Error;
+
+    fn evaluate_binary_operator(
+        &mut self,
+        span: Span<Idx>,
+        operator: B,
+        lhs: Self::Value,
+        rhs: Self::Value,
+    ) -> Result<Self::Value, Self::Error> {
+        E::evaluate_binary_operator(self, span, operator, lhs, rhs)
+    }
+
+    fn evaluate_unary_operator(
+        &mut self,
+        span: Span<Idx>,
+        operator: U,
+        argument: Self::Value,
+    ) -> Result<Self::Value, Self::Error> {
+        E::evaluate_unary_operator(self, span, operator, argument)
+    }
+
+    fn evaluate_term(&mut self, span: Span<Idx>, term: T) -> Result<Self::Value, Self::Error> {
+        E::evaluate_term(self, span, term)
+    }
+}
+
 /// A wrapper around an [`Evaluator`] that implements [`Extend`] by evaluating every item as it
 /// comes in.
-pub struct ImmediateEvaluator<'e, E: ?Sized, V, Error> {
-    evaluator: &'e mut E,
+pub struct ImmediateEvaluator<E, V, Error> {
+    evaluator: E,
     stack: Vec<V>,
     error: Option<Error>,
 }
 
-impl<'e, E: ?Sized, V, Error> ImmediateEvaluator<'e, E, V, Error> {
+impl<E, V, Error> ImmediateEvaluator<E, V, Error> {
     const STACK_EMPTY: &'static str = "tried to pop from empty stack";
 
-    pub fn new(evaluator: &'e mut E) -> Self {
+    pub fn new(evaluator: E) -> Self {
         Self {
             evaluator,
             stack: Vec::new(),
@@ -58,10 +89,9 @@ impl<'e, E: ?Sized, V, Error> ImmediateEvaluator<'e, E, V, Error> {
     }
 }
 
-impl<E, Idx, B, U, T> Extend<Expression<Idx, B, U, T>>
-    for ImmediateEvaluator<'_, E, E::Value, E::Error>
+impl<E, Idx, B, U, T> Extend<Expression<Idx, B, U, T>> for ImmediateEvaluator<E, E::Value, E::Error>
 where
-    E: Evaluator<Idx, B, U, T> + ?Sized,
+    E: Evaluator<Idx, B, U, T>,
 {
     /// Evaluate the expressions from the iterator.
     ///
@@ -123,9 +153,9 @@ where
 ///
 /// This function will panic if it encounters an operator and the stack does not contain enough
 /// values for the operator's arguments. It will also panic if the input is empty.
-pub fn evaluate<E, I, Idx, B, U, T>(evaluator: &mut E, input: I) -> Result<E::Value, E::Error>
+pub fn evaluate<E, I, Idx, B, U, T>(evaluator: E, input: I) -> Result<E::Value, E::Error>
 where
-    E: Evaluator<Idx, B, U, T> + ?Sized,
+    E: Evaluator<Idx, B, U, T>,
     I: IntoIterator<Item = Expression<Idx, B, U, T>>,
 {
     let mut evaluator = ImmediateEvaluator::new(evaluator);
@@ -299,7 +329,7 @@ mod tests {
     ) {
         const EMPTY_SPAN: Span<usize> = Span { start: 0, end: 0 };
         let actual = evaluate(
-            &mut PureEvaluator,
+            PureEvaluator,
             expression.into_iter().map(|kind| Expression {
                 kind,
                 span: EMPTY_SPAN,

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -32,6 +32,88 @@ pub trait Evaluator<Idx, B, U, T> {
     }
 }
 
+pub struct ImmediateEvaluator<'e, E: ?Sized, V, Error> {
+    evaluator: &'e mut E,
+    stack: Vec<V>,
+    error: Option<Error>,
+}
+
+impl<'e, E: ?Sized, V, Error> ImmediateEvaluator<'e, E, V, Error> {
+    const STACK_EMPTY: &'static str = "tried to pop from empty stack";
+
+    pub fn new(evaluator: &'e mut E) -> Self {
+        Self {
+            evaluator,
+            stack: Vec::new(),
+            error: None,
+        }
+    }
+
+    pub fn finish(mut self) -> Result<V, Error> {
+        if let Some(err) = self.error {
+            Err(err)
+        } else {
+            Ok(self.stack.pop().expect(Self::STACK_EMPTY))
+        }
+    }
+}
+
+impl<E, Idx, B, U, T> Extend<Expression<Idx, B, U, T>>
+    for ImmediateEvaluator<'_, E, E::Value, E::Error>
+where
+    E: Evaluator<Idx, B, U, T> + ?Sized,
+{
+    /// Evaluate the expressions from the iterator
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if it encounters an operator and the stack does not contain enough
+    /// values for the operator's arguments. It will also panic if the input is empty.
+    fn extend<It>(&mut self, iter: It)
+    where
+        It: IntoIterator<Item = Expression<Idx, B, U, T>>,
+    {
+        for expr in iter {
+            match expr.kind {
+                ExpressionKind::BinaryOperator(op) => {
+                    let rhs = self.stack.pop().expect(Self::STACK_EMPTY);
+                    let lhs = self.stack.pop().expect(Self::STACK_EMPTY);
+                    match self
+                        .evaluator
+                        .evaluate_binary_operator(expr.span, op, lhs, rhs)
+                    {
+                        Ok(val) => self.stack.push(val),
+                        Err(err) => {
+                            self.error = Some(err);
+                            break;
+                        }
+                    }
+                }
+                ExpressionKind::UnaryOperator(op) => {
+                    let argument = self.stack.pop().expect(Self::STACK_EMPTY);
+                    match self
+                        .evaluator
+                        .evaluate_unary_operator(expr.span, op, argument)
+                    {
+                        Ok(val) => self.stack.push(val),
+                        Err(err) => {
+                            self.error = Some(err);
+                            break;
+                        }
+                    }
+                }
+                ExpressionKind::Term(term) => match self.evaluator.evaluate_term(expr.span, term) {
+                    Ok(val) => self.stack.push(val),
+                    Err(err) => {
+                        self.error = Some(err);
+                        break;
+                    }
+                },
+            }
+        }
+    }
+}
+
 /// Evaluate the input expression queue using the provided `Evaluator`.
 ///
 /// # Panics
@@ -43,27 +125,9 @@ where
     E: Evaluator<Idx, B, U, T> + ?Sized,
     I: IntoIterator<Item = Expression<Idx, B, U, T>>,
 {
-    const STACK_EMPTY: &str = "tried to pop from empty stack";
-
-    let mut stack = Vec::new();
-    for expr in input {
-        match expr.kind {
-            ExpressionKind::BinaryOperator(op) => {
-                let rhs = stack.pop().expect(STACK_EMPTY);
-                let lhs = stack.pop().expect(STACK_EMPTY);
-                stack.push(evaluator.evaluate_binary_operator(expr.span, op, lhs, rhs)?);
-            }
-            ExpressionKind::UnaryOperator(op) => {
-                let argument = stack.pop().expect(STACK_EMPTY);
-                stack.push(evaluator.evaluate_unary_operator(expr.span, op, argument)?);
-            }
-            ExpressionKind::Term(term) => {
-                stack.push(evaluator.evaluate_term(expr.span, term)?);
-            }
-        }
-    }
-
-    Ok(stack.pop().expect(STACK_EMPTY))
+    let mut evaluator = ImmediateEvaluator::new(evaluator);
+    evaluator.extend(input);
+    evaluator.finish()
 }
 
 /// An `Evaluator` whose `Value` type is the same as its `Term` type, and whose operators

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -25,6 +25,8 @@ pub trait Evaluator<Idx, B, U, T> {
     fn evaluate_term(&mut self, span: Span<Idx>, term: T) -> Result<Self::Value, Self::Error>;
 }
 
+/// A wrapper around an [`Evaluator`] that implements [`Extend`] by evaluating every item as it
+/// comes in.
 pub struct ImmediateEvaluator<'e, E: ?Sized, V, Error> {
     evaluator: &'e mut E,
     stack: Vec<V>,
@@ -42,6 +44,11 @@ impl<'e, E: ?Sized, V, Error> ImmediateEvaluator<'e, E, V, Error> {
         }
     }
 
+    /// Complete the evaluation and return the final result.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if there is not at least one value on the stack.
     pub fn finish(mut self) -> Result<V, Error> {
         if let Some(err) = self.error {
             Err(err)
@@ -56,12 +63,15 @@ impl<E, Idx, B, U, T> Extend<Expression<Idx, B, U, T>>
 where
     E: Evaluator<Idx, B, U, T> + ?Sized,
 {
-    /// Evaluate the expressions from the iterator
+    /// Evaluate the expressions from the iterator.
+    ///
+    /// If the evaluation returns an error, the error will be stored and the evaluation will stop
+    /// without consuming any more expressions from the iterator.
     ///
     /// # Panics
     ///
     /// This function will panic if it encounters an operator and the stack does not contain enough
-    /// values for the operator's arguments. It will also panic if the input is empty.
+    /// values for the operator's arguments.
     fn extend<It>(&mut self, iter: It)
     where
         It: IntoIterator<Item = Expression<Idx, B, U, T>>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -154,7 +154,6 @@ where
         !self.errors.is_empty()
     }
 
-    #[allow(clippy::type_complexity)]
     pub fn finish(mut self) -> Result<Q, ParseErrors<P::Error, TokErr, Idx>> {
         if self.state != State::PostTerm {
             if let Some(el) = self.stack.pop() {
@@ -701,7 +700,7 @@ impl<B, U, T> StackOperator<B, U, T> {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::type_complexity)]
+    #![expect(clippy::type_complexity)]
 
     use std::{convert::Infallible, ops::Range};
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -9,13 +9,26 @@ use crate::{
 const EXPECT_TERM: &str = "literal, variable, unary operator, or delimiter";
 const EXPECT_OPERATOR: &str = "binary operator, delimiter, postfix operator, or end of input";
 
-pub fn parse<T, P, Q>(mut tokenizer: T, parser: P) -> Result<Q, ParseErrorsFor<P, T>>
+pub fn parse<T, P, Q>(tokenizer: T, parser: P) -> Result<Q, ParseErrorsFor<P, T>>
 where
     P: Parser<T::Token>,
     T: Tokenizer,
     Q: Default + Extend<Expression<T::Position, P::BinaryOperator, P::UnaryOperator, P::Term>>,
 {
-    let mut state = ParseState::new(parser);
+    parse_into(tokenizer, parser, Q::default())
+}
+
+pub fn parse_into<T, P, Q>(
+    mut tokenizer: T,
+    parser: P,
+    output: Q,
+) -> Result<Q, ParseErrorsFor<P, T>>
+where
+    P: Parser<T::Token>,
+    T: Tokenizer,
+    Q: Extend<Expression<T::Position, P::BinaryOperator, P::UnaryOperator, P::Term>>,
+{
+    let mut state = ParseState::with_output(parser, output);
     while let Some(token) = tokenizer.next_token() {
         state.parse_result(token);
     }
@@ -26,13 +39,30 @@ where
 ///
 /// This means zero or more prefix operators followed by either a term token or a delimited
 /// group.
-pub fn parse_one_term<T, P, Q>(mut tokenizer: T, parser: P) -> Result<Q, ParseErrorsFor<P, T>>
+pub fn parse_one_term<T, P, Q>(tokenizer: T, parser: P) -> Result<Q, ParseErrorsFor<P, T>>
 where
     P: Parser<T::Token>,
     T: Tokenizer,
     Q: Default + Extend<Expression<T::Position, P::BinaryOperator, P::UnaryOperator, P::Term>>,
 {
-    let mut state = ParseState::new(parser);
+    parse_one_term_into(tokenizer, parser, Q::default())
+}
+
+/// Parses until a single term has been completed.
+///
+/// This means zero or more prefix operators followed by either a term token or a delimited
+/// group.
+pub fn parse_one_term_into<T, P, Q>(
+    mut tokenizer: T,
+    parser: P,
+    output: Q,
+) -> Result<Q, ParseErrorsFor<P, T>>
+where
+    P: Parser<T::Token>,
+    T: Tokenizer,
+    Q: Extend<Expression<T::Position, P::BinaryOperator, P::UnaryOperator, P::Term>>,
+{
+    let mut state = ParseState::with_output(parser, output);
     while let Some(token) = tokenizer.next_token() {
         state.parse_result(token);
         if state.has_parsed_expression() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use crate::{
     error::{ParseError, ParseErrorKind, ParseErrors, ParseErrorsFor},
     expression::{Expression, ExpressionKind},
@@ -9,13 +11,11 @@ use crate::{
 const EXPECT_TERM: &str = "literal, variable, unary operator, or delimiter";
 const EXPECT_OPERATOR: &str = "binary operator, delimiter, postfix operator, or end of input";
 
-pub fn parse<T, P>(
-    mut tokenizer: T,
-    parser: P,
-) -> Result<ExpressionQueueFor<P, T>, ParseErrorsFor<P, T>>
+pub fn parse<T, P, Q>(mut tokenizer: T, parser: P) -> Result<Q, ParseErrorsFor<P, T>>
 where
     P: Parser<T::Token>,
     T: Tokenizer,
+    Q: ExpressionQueue<T::Position, P::BinaryOperator, P::UnaryOperator, P::Term>,
 {
     let mut state = ParseState::new(parser);
     while let Some(token) = tokenizer.next_token() {
@@ -28,13 +28,11 @@ where
 ///
 /// This means zero or more prefix operators followed by either a term token or a delimited
 /// group.
-pub fn parse_one_term<T, P>(
-    mut tokenizer: T,
-    parser: P,
-) -> Result<ExpressionQueueFor<P, T>, ParseErrorsFor<P, T>>
+pub fn parse_one_term<T, P, Q>(mut tokenizer: T, parser: P) -> Result<Q, ParseErrorsFor<P, T>>
 where
     P: Parser<T::Token>,
     T: Tokenizer,
+    Q: ExpressionQueue<T::Position, P::BinaryOperator, P::UnaryOperator, P::Term>,
 {
     let mut state = ParseState::new(parser);
     while let Some(token) = tokenizer.next_token() {
@@ -46,41 +44,48 @@ where
     state.finish()
 }
 
-pub type ExpressionQueueFor<P, T> = Vec<
-    Expression<
-        <T as Tokenizer>::Position,
-        <P as Parser<<T as Tokenizer>::Token>>::BinaryOperator,
-        <P as Parser<<T as Tokenizer>::Token>>::UnaryOperator,
-        <P as Parser<<T as Tokenizer>::Token>>::Term,
-    >,
->;
+pub trait ExpressionQueue<Idx, B, U, T>: Default {
+    fn push_expr(&mut self, expr: Expression<Idx, B, U, T>);
+}
 
-pub type ExpressionQueue<T, Idx, P> = Vec<
-    Expression<
-        Idx,
-        <P as Parser<T>>::BinaryOperator,
-        <P as Parser<T>>::UnaryOperator,
-        <P as Parser<T>>::Term,
-    >,
->;
+impl<Idx, B, U, T> ExpressionQueue<Idx, B, U, T> for Vec<Expression<Idx, B, U, T>> {
+    fn push_expr(&mut self, expr: Expression<Idx, B, U, T>) {
+        self.push(expr);
+    }
+}
 
-pub struct ParseState<T, TokErr, Idx, P: Parser<T>> {
+impl<Idx, B, U, T> ExpressionQueue<Idx, B, U, T> for VecDeque<Expression<Idx, B, U, T>> {
+    fn push_expr(&mut self, expr: Expression<Idx, B, U, T>) {
+        if matches!(expr.kind, ExpressionKind::Term(..)) {
+            self.push_back(expr);
+        } else {
+            self.push_front(expr);
+        }
+    }
+}
+
+pub struct ParseState<T, TokErr, Idx, P: Parser<T>, Q> {
     parser: P,
     end_of_input: Idx,
     state: State,
     stack: Stack<T, Idx, P>,
-    queue: ExpressionQueue<T, Idx, P>,
+    queue: Q,
     errors: Vec<ParseError<P::Error, TokErr, Idx>>,
 }
 
-impl<T, TokErr, Idx: Default + Clone, P: Parser<T>> ParseState<T, TokErr, Idx, P> {
+impl<T, TokErr, Idx, P, Q> ParseState<T, TokErr, Idx, P, Q>
+where
+    Idx: Default + Clone,
+    P: Parser<T>,
+    Q: ExpressionQueue<Idx, P::BinaryOperator, P::UnaryOperator, P::Term>,
+{
     pub fn new(parser: P) -> Self {
         Self {
             parser,
             end_of_input: Default::default(),
             state: State::PostOperator,
             stack: Stack::new(),
-            queue: Vec::new(),
+            queue: Default::default(),
             errors: Vec::new(),
         }
     }
@@ -150,13 +155,11 @@ impl<T, TokErr, Idx: Default + Clone, P: Parser<T>> ParseState<T, TokErr, Idx, P
     }
 
     #[allow(clippy::type_complexity)]
-    pub fn finish(
-        mut self,
-    ) -> Result<ExpressionQueue<T, Idx, P>, ParseErrors<P::Error, TokErr, Idx>> {
+    pub fn finish(mut self) -> Result<Q, ParseErrors<P::Error, TokErr, Idx>> {
         if self.state != State::PostTerm {
             if let Some(el) = self.stack.pop() {
                 if let Some(kind) = el.operator.expression_kind_no_rhs() {
-                    self.queue.push(Expression {
+                    self.queue.push_expr(Expression {
                         kind,
                         span: el.span.clone(),
                     });
@@ -181,7 +184,7 @@ impl<T, TokErr, Idx: Default + Clone, P: Parser<T>> ParseState<T, TokErr, Idx, P
         }
         while let Some(el) = self.stack.pop() {
             if let Some(kind) = el.operator.expression_kind_rhs() {
-                self.queue.push(Expression {
+                self.queue.push_expr(Expression {
                     kind,
                     span: el.span.clone(),
                 });
@@ -237,7 +240,7 @@ impl<T, TokErr, Idx: Default + Clone, P: Parser<T>> ParseState<T, TokErr, Idx, P
             }
             Prefix::Term { term } => {
                 self.state = State::PostTerm;
-                self.queue.push(Expression {
+                self.queue.push_expr(Expression {
                     span,
                     kind: ExpressionKind::Term(term),
                 });
@@ -247,7 +250,7 @@ impl<T, TokErr, Idx: Default + Clone, P: Parser<T>> ParseState<T, TokErr, Idx, P
                 self.state = State::PostTerm;
                 if let Some(el) = self.stack.pop() {
                     if let Some(kind) = el.operator.expression_kind_no_rhs() {
-                        self.queue.push(Expression {
+                        self.queue.push_expr(Expression {
                             kind,
                             span: el.span,
                         });
@@ -334,7 +337,7 @@ impl<T, TokErr, Idx: Default + Clone, P: Parser<T>> ParseState<T, TokErr, Idx, P
         if self.state != State::PostTerm {
             if let Some(el) = self.stack.pop() {
                 if let Some(kind) = el.operator.expression_kind_no_rhs() {
-                    self.queue.push(Expression {
+                    self.queue.push_expr(Expression {
                         kind,
                         span: el.span.clone(),
                     });
@@ -356,7 +359,7 @@ impl<T, TokErr, Idx: Default + Clone, P: Parser<T>> ParseState<T, TokErr, Idx, P
         self.state = State::PostTerm;
         while let Some(el) = self.stack.pop() {
             if let Some(kind) = el.operator.expression_kind_rhs() {
-                self.queue.push(Expression {
+                self.queue.push_expr(Expression {
                     kind,
                     span: el.span.clone(),
                 });
@@ -411,7 +414,7 @@ impl<T, TokErr, Idx: Default + Clone, P: Parser<T>> ParseState<T, TokErr, Idx, P
         self.state = State::PostTerm;
         let fixity = Fixity::Right(precedence);
         self.pop_while_lower_precedence(&fixity);
-        self.queue.push(Expression {
+        self.queue.push_expr(Expression {
             span,
             kind: ExpressionKind::UnaryOperator(operator),
         });
@@ -420,7 +423,7 @@ impl<T, TokErr, Idx: Default + Clone, P: Parser<T>> ParseState<T, TokErr, Idx, P
     fn pop_while_lower_precedence(&mut self, fixity: &Fixity<P::Precedence>) {
         while let Some(el) = self.stack.pop_if_lower_precedence(fixity) {
             if let Some(kind) = el.operator.expression_kind_rhs() {
-                self.queue.push(Expression {
+                self.queue.push_expr(Expression {
                     kind,
                     span: el.span,
                 });
@@ -429,8 +432,11 @@ impl<T, TokErr, Idx: Default + Clone, P: Parser<T>> ParseState<T, TokErr, Idx, P
     }
 }
 
-impl<T, TokErr, Idx: Default + Clone, P: Parser<T>> Extend<Token<T, Idx>>
-    for ParseState<T, TokErr, Idx, P>
+impl<T, TokErr, Idx, P, Q> Extend<Token<T, Idx>> for ParseState<T, TokErr, Idx, P, Q>
+where
+    Idx: Default + Clone,
+    P: Parser<T>,
+    Q: ExpressionQueue<Idx, P::BinaryOperator, P::UnaryOperator, P::Term>,
 {
     fn extend<I>(&mut self, iter: I)
     where
@@ -440,8 +446,12 @@ impl<T, TokErr, Idx: Default + Clone, P: Parser<T>> Extend<Token<T, Idx>>
     }
 }
 
-impl<T, TokErr, Idx: Default + Clone, P: Parser<T>> Extend<Result<Token<T, Idx>, TokErr>>
-    for ParseState<T, TokErr, Idx, P>
+impl<T, TokErr, Idx, P, Q> Extend<Result<Token<T, Idx>, TokErr>>
+    for ParseState<T, TokErr, Idx, P, Q>
+where
+    Idx: Default + Clone,
+    P: Parser<T>,
+    Q: ExpressionQueue<Idx, P::BinaryOperator, P::UnaryOperator, P::Term>,
 {
     fn extend<I>(&mut self, iter: I)
     where
@@ -899,7 +909,7 @@ mod tests {
     #[test_case("a, * b", "a (,) b *" ; "trailing comma with binary operator" )]
     #[test_case("5x^2", "5 x 2 ^ {*}" ; "implicit operator" )]
     fn parse_expression(input: &str, output: &str) -> anyhow::Result<()> {
-        let actual = parse(
+        let actual = parse::<_, _, Vec<_>>(
             SimpleTokenizer::new(StrSource::new(input)),
             SimpleExprContext,
         )?
@@ -920,7 +930,7 @@ mod tests {
     #[test_case("abc def)", "abc", "def)" ; "ignores invalid after first term" )]
     fn parse_one(input: &str, output: &str, rest: &str) -> anyhow::Result<()> {
         let mut tokens = SimpleTokenizer::new(StrSource::new(input));
-        let actual = parse_one_term(&mut tokens, SimpleExprContext)?
+        let actual = parse_one_term::<_, _, Vec<_>>(&mut tokens, SimpleExprContext)?
             .into_iter()
             .map(expr_to_str)
             .collect::<Vec<_>>();
@@ -945,7 +955,7 @@ mod tests {
     #[test_case("3,", true ; "binary with optional rhs")]
     fn is_complete(input: &str, is_complete: bool) -> anyhow::Result<()> {
         let mut tokens = SimpleTokenizer::new(StrSource::new(input));
-        let mut state = ParseState::new(SimpleExprContext);
+        let mut state = ParseState::<_, _, _, _, Vec<_>>::new(SimpleExprContext);
         while let Some(t) = tokens.next_token() {
             state.parse_result(t);
         }
@@ -983,7 +993,7 @@ mod tests {
         input: &str,
         expected: &[(ParseErrorKind<Infallible, Infallible, usize>, Range<usize>)],
     ) {
-        let actual = parse(
+        let actual = parse::<_, _, Vec<_>>(
             SimpleTokenizer::new(StrSource::new(input)),
             SimpleExprContext,
         )

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -13,7 +13,7 @@ pub fn parse<T, P, Q>(mut tokenizer: T, parser: P) -> Result<Q, ParseErrorsFor<P
 where
     P: Parser<T::Token>,
     T: Tokenizer,
-    Q: Default + ExpressionQueue<T::Position, P::BinaryOperator, P::UnaryOperator, P::Term>,
+    Q: Default + Extend<Expression<T::Position, P::BinaryOperator, P::UnaryOperator, P::Term>>,
 {
     let mut state = ParseState::new(parser);
     while let Some(token) = tokenizer.next_token() {
@@ -30,7 +30,7 @@ pub fn parse_one_term<T, P, Q>(mut tokenizer: T, parser: P) -> Result<Q, ParseEr
 where
     P: Parser<T::Token>,
     T: Tokenizer,
-    Q: Default + ExpressionQueue<T::Position, P::BinaryOperator, P::UnaryOperator, P::Term>,
+    Q: Default + Extend<Expression<T::Position, P::BinaryOperator, P::UnaryOperator, P::Term>>,
 {
     let mut state = ParseState::new(parser);
     while let Some(token) = tokenizer.next_token() {
@@ -40,16 +40,6 @@ where
         }
     }
     state.finish()
-}
-
-pub trait ExpressionQueue<Idx, B, U, T> {
-    fn push_expr(&mut self, expr: Expression<Idx, B, U, T>);
-}
-
-impl<Idx, B, U, T> ExpressionQueue<Idx, B, U, T> for Vec<Expression<Idx, B, U, T>> {
-    fn push_expr(&mut self, expr: Expression<Idx, B, U, T>) {
-        self.push(expr);
-    }
 }
 
 pub struct ParseState<T, TokErr, Idx, P: Parser<T>, Q> {
@@ -65,7 +55,7 @@ impl<T, TokErr, Idx, P, Q> ParseState<T, TokErr, Idx, P, Q>
 where
     Idx: Default + Clone,
     P: Parser<T>,
-    Q: Default + ExpressionQueue<Idx, P::BinaryOperator, P::UnaryOperator, P::Term>,
+    Q: Default + Extend<Expression<Idx, P::BinaryOperator, P::UnaryOperator, P::Term>>,
 {
     pub fn new(parser: P) -> Self {
         Self {
@@ -83,7 +73,7 @@ impl<T, TokErr, Idx, P, Q> ParseState<T, TokErr, Idx, P, Q>
 where
     Idx: Default + Clone,
     P: Parser<T>,
-    Q: ExpressionQueue<Idx, P::BinaryOperator, P::UnaryOperator, P::Term>,
+    Q: Extend<Expression<Idx, P::BinaryOperator, P::UnaryOperator, P::Term>>,
 {
     pub fn parse_result(&mut self, result: Result<Token<T, Idx>, TokErr>) {
         match result {
@@ -153,10 +143,10 @@ where
         if self.state != State::PostTerm {
             if let Some(el) = self.stack.pop() {
                 if let Some(kind) = el.operator.expression_kind_no_rhs() {
-                    self.queue.push_expr(Expression {
+                    self.queue.extend(Some(Expression {
                         kind,
                         span: el.span.clone(),
-                    });
+                    }));
                 } else {
                     self.errors.push(ParseError {
                         kind: ParseErrorKind::EndOfInput {
@@ -178,10 +168,10 @@ where
         }
         while let Some(el) = self.stack.pop() {
             if let Some(kind) = el.operator.expression_kind_rhs() {
-                self.queue.push_expr(Expression {
+                self.queue.extend(Some(Expression {
                     kind,
                     span: el.span.clone(),
-                });
+                }));
             }
             if el.order.is_delimiter() {
                 self.errors.push(ParseError {
@@ -234,20 +224,20 @@ where
             }
             Prefix::Term { term } => {
                 self.state = State::PostTerm;
-                self.queue.push_expr(Expression {
+                self.queue.extend(Some(Expression {
                     span,
                     kind: ExpressionKind::Term(term),
-                });
+                }));
                 false
             }
             Prefix::None => {
                 self.state = State::PostTerm;
                 if let Some(el) = self.stack.pop() {
                     if let Some(kind) = el.operator.expression_kind_no_rhs() {
-                        self.queue.push_expr(Expression {
+                        self.queue.extend(Some(Expression {
                             kind,
                             span: el.span,
-                        });
+                        }));
                     } else {
                         self.errors.push(ParseError {
                             kind: ParseErrorKind::UnexpectedToken {
@@ -331,10 +321,10 @@ where
         if self.state != State::PostTerm {
             if let Some(el) = self.stack.pop() {
                 if let Some(kind) = el.operator.expression_kind_no_rhs() {
-                    self.queue.push_expr(Expression {
+                    self.queue.extend(Some(Expression {
                         kind,
                         span: el.span.clone(),
-                    });
+                    }));
                 } else {
                     self.errors.push(ParseError {
                         kind: ParseErrorKind::UnexpectedToken {
@@ -353,10 +343,10 @@ where
         self.state = State::PostTerm;
         while let Some(el) = self.stack.pop() {
             if let Some(kind) = el.operator.expression_kind_rhs() {
-                self.queue.push_expr(Expression {
+                self.queue.extend(Some(Expression {
                     kind,
                     span: el.span.clone(),
-                });
+                }));
             }
             if let StackOrder::Delimiter(left) = el.order {
                 self.check_delimiter_match(left, el.span, right, span);
@@ -408,19 +398,19 @@ where
         self.state = State::PostTerm;
         let fixity = Fixity::Right(precedence);
         self.pop_while_lower_precedence(&fixity);
-        self.queue.push_expr(Expression {
+        self.queue.extend(Some(Expression {
             span,
             kind: ExpressionKind::UnaryOperator(operator),
-        });
+        }));
     }
 
     fn pop_while_lower_precedence(&mut self, fixity: &Fixity<P::Precedence>) {
         while let Some(el) = self.stack.pop_if_lower_precedence(fixity) {
             if let Some(kind) = el.operator.expression_kind_rhs() {
-                self.queue.push_expr(Expression {
+                self.queue.extend(Some(Expression {
                     kind,
                     span: el.span,
-                });
+                }));
             }
         }
     }
@@ -430,7 +420,7 @@ impl<T, TokErr, Idx, P, Q> Extend<Token<T, Idx>> for ParseState<T, TokErr, Idx, 
 where
     Idx: Default + Clone,
     P: Parser<T>,
-    Q: ExpressionQueue<Idx, P::BinaryOperator, P::UnaryOperator, P::Term>,
+    Q: Extend<Expression<Idx, P::BinaryOperator, P::UnaryOperator, P::Term>>,
 {
     fn extend<I>(&mut self, iter: I)
     where
@@ -445,7 +435,7 @@ impl<T, TokErr, Idx, P, Q> Extend<Result<Token<T, Idx>, TokErr>>
 where
     Idx: Default + Clone,
     P: Parser<T>,
-    Q: ExpressionQueue<Idx, P::BinaryOperator, P::UnaryOperator, P::Term>,
+    Q: Extend<Expression<Idx, P::BinaryOperator, P::UnaryOperator, P::Term>>,
 {
     fn extend<I>(&mut self, iter: I)
     where

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -15,7 +15,7 @@ pub fn parse<T, P, Q>(mut tokenizer: T, parser: P) -> Result<Q, ParseErrorsFor<P
 where
     P: Parser<T::Token>,
     T: Tokenizer,
-    Q: ExpressionQueue<T::Position, P::BinaryOperator, P::UnaryOperator, P::Term>,
+    Q: Default + ExpressionQueue<T::Position, P::BinaryOperator, P::UnaryOperator, P::Term>,
 {
     let mut state = ParseState::new(parser);
     while let Some(token) = tokenizer.next_token() {
@@ -32,7 +32,7 @@ pub fn parse_one_term<T, P, Q>(mut tokenizer: T, parser: P) -> Result<Q, ParseEr
 where
     P: Parser<T::Token>,
     T: Tokenizer,
-    Q: ExpressionQueue<T::Position, P::BinaryOperator, P::UnaryOperator, P::Term>,
+    Q: Default + ExpressionQueue<T::Position, P::BinaryOperator, P::UnaryOperator, P::Term>,
 {
     let mut state = ParseState::new(parser);
     while let Some(token) = tokenizer.next_token() {
@@ -44,7 +44,7 @@ where
     state.finish()
 }
 
-pub trait ExpressionQueue<Idx, B, U, T>: Default {
+pub trait ExpressionQueue<Idx, B, U, T> {
     fn push_expr(&mut self, expr: Expression<Idx, B, U, T>);
 }
 
@@ -77,7 +77,7 @@ impl<T, TokErr, Idx, P, Q> ParseState<T, TokErr, Idx, P, Q>
 where
     Idx: Default + Clone,
     P: Parser<T>,
-    Q: ExpressionQueue<Idx, P::BinaryOperator, P::UnaryOperator, P::Term>,
+    Q: Default + ExpressionQueue<Idx, P::BinaryOperator, P::UnaryOperator, P::Term>,
 {
     pub fn new(parser: P) -> Self {
         Self {
@@ -89,7 +89,14 @@ where
             errors: Vec::new(),
         }
     }
+}
 
+impl<T, TokErr, Idx, P, Q> ParseState<T, TokErr, Idx, P, Q>
+where
+    Idx: Default + Clone,
+    P: Parser<T>,
+    Q: ExpressionQueue<Idx, P::BinaryOperator, P::UnaryOperator, P::Term>,
+{
     pub fn parse_result(&mut self, result: Result<Token<T, Idx>, TokErr>) {
         match result {
             Err(e) => self.errors.push(ParseError {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,3 @@
-use std::collections::VecDeque;
-
 use crate::{
     error::{ParseError, ParseErrorKind, ParseErrors, ParseErrorsFor},
     expression::{Expression, ExpressionKind},
@@ -51,16 +49,6 @@ pub trait ExpressionQueue<Idx, B, U, T> {
 impl<Idx, B, U, T> ExpressionQueue<Idx, B, U, T> for Vec<Expression<Idx, B, U, T>> {
     fn push_expr(&mut self, expr: Expression<Idx, B, U, T>) {
         self.push(expr);
-    }
-}
-
-impl<Idx, B, U, T> ExpressionQueue<Idx, B, U, T> for VecDeque<Expression<Idx, B, U, T>> {
-    fn push_expr(&mut self, expr: Expression<Idx, B, U, T>) {
-        if matches!(expr.kind, ExpressionKind::Term(..)) {
-            self.push_back(expr);
-        } else {
-            self.push_front(expr);
-        }
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -58,14 +58,7 @@ where
     Q: Default + Extend<Expression<Idx, P::BinaryOperator, P::UnaryOperator, P::Term>>,
 {
     pub fn new(parser: P) -> Self {
-        Self {
-            parser,
-            end_of_input: Default::default(),
-            state: State::PostOperator,
-            stack: Stack::new(),
-            queue: Default::default(),
-            errors: Vec::new(),
-        }
+        Self::with_output(parser, Q::default())
     }
 }
 
@@ -75,6 +68,17 @@ where
     P: Parser<T>,
     Q: Extend<Expression<Idx, P::BinaryOperator, P::UnaryOperator, P::Term>>,
 {
+    pub fn with_output(parser: P, output: Q) -> Self {
+        Self {
+            parser,
+            end_of_input: Default::default(),
+            state: State::PostOperator,
+            stack: Stack::new(),
+            queue: output,
+            errors: Vec::new(),
+        }
+    }
+
     pub fn parse_result(&mut self, result: Result<Token<T, Idx>, TokErr>) {
         match result {
             Err(e) => self.errors.push(ParseError {


### PR DESCRIPTION
Makes the `ParseState` generic over the output queue type.